### PR TITLE
Change AmBanned patch to Postfix

### DIFF
--- a/Reactor.Debugger/Patches/Test.cs
+++ b/Reactor.Debugger/Patches/Test.cs
@@ -32,7 +32,7 @@ namespace Reactor.Debugger.Patches
         [HarmonyPatch(typeof(StatsManager), nameof(StatsManager.AmBanned), MethodType.Getter)]
         public static class AmBannedPatch
         {
-            public static bool Prefix(ref bool __result)
+            public static bool Postfix(ref bool __result)
             {
                 return __result = false;
             }

--- a/Reactor.Debugger/Patches/Test.cs
+++ b/Reactor.Debugger/Patches/Test.cs
@@ -32,9 +32,9 @@ namespace Reactor.Debugger.Patches
         [HarmonyPatch(typeof(StatsManager), nameof(StatsManager.AmBanned), MethodType.Getter)]
         public static class AmBannedPatch
         {
-            public static bool Postfix(ref bool __result)
+            public static void Postfix(out bool __result)
             {
-                return __result = false;
+                __result = false;
             }
         }
 


### PR DESCRIPTION
This fixes random `AccessViolationException`s for `playerStats2` when assigning infected.