### PR TITLE
Remove readonly modifier from ExampleRpc.Data struct

### DIFF
--- a/Reactor.Example/ExampleRpc.cs
+++ b/Reactor.Example/ExampleRpc.cs
@@ -9,7 +9,7 @@ namespace Reactor.Example
         {
         }
 
-        public readonly struct Data
+        public struct Data
         {
             public readonly string Message;
 


### PR DESCRIPTION
Addresses two "unresolved member reference" warnings during build.