### PR TITLE
Block non-Reactor custom RPCs in normal servers.

### DIFF
--- a/Reactor/Extensions/Extensions.cs
+++ b/Reactor/Extensions/Extensions.cs
@@ -114,5 +114,10 @@ namespace Reactor.Extensions
         {
             return assetBundle.LoadAsset(name, Il2CppType.Of<T>())?.Cast<T>();
         }
+
+        public static T GetHighestValue<TEnum, T>() where TEnum : Enum
+        {
+            return Enum.GetValues(typeof(TEnum)).Cast<T>().Max();
+        }
     }
 }


### PR DESCRIPTION
Simplified coroutine condition.

Untested since I don't use or make any mods with non-Reactor custom RPCs, as long as my assignments of `CustomServer` are in the right place, this should work correctly.