### PR TITLE
Fix CI Caching by cloning first

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,17 @@
 name: CI
 
-on: [ "push", "pull_request" ]
+on: ["push", "pull_request"]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.nuget/packages
@@ -15,10 +19,6 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
-
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
The cache action requires the checksum of the packages.lock.json files,
but can't find them because the repository wasn't cloned yet. So clone
the repository first