### PR TITLE
Fix Game lists not working on legacy mm servers

### DIFF
--- a/Reactor/Patches/Fixes/CoFindGamePatch.cs
+++ b/Reactor/Patches/Fixes/CoFindGamePatch.cs
@@ -1,0 +1,18 @@
+using HarmonyLib;
+
+namespace Reactor.Patches.Fixes;
+
+/// <summary>
+/// Fixes Game Lists not working on servers using legacy matchmaking.
+/// </summary>
+[HarmonyPatch(typeof(AmongUsClient._CoFindGame_d__3), nameof(AmongUsClient._CoFindGame_d__3.MoveNext))]
+internal static class CoFindGamePatch
+{
+    public static void Prefix()
+    {
+        if (AmongUsClient.Instance.LastDisconnectReason == DisconnectReasons.Unknown)
+        {
+            AmongUsClient.Instance.LastDisconnectReason = DisconnectReasons.ExitGame;
+        }
+    }
+}


### PR DESCRIPTION
This happens because InnerNetClient.CoConnect now sets the default LastDisconnectReason to Unknown instead of ExitGame, which breaks the public game list screen.

Co-Authored-By: Edward Smale <essmale2005@gmail.com>