### PR TITLE
Improve handshake popup

### DIFF
--- a/Reactor/Networking/HandshakePopup.cs
+++ b/Reactor/Networking/HandshakePopup.cs
@@ -1,3 +1,6 @@
+using Reactor.Utilities.UI;
+using UnityEngine;
+
 namespace Reactor.Networking;
 
 internal static class HandshakePopup
@@ -9,8 +12,18 @@ internal static class HandshakePopup
         For more info see <link=https://reactor.gg/handshake>reactor.gg/handshake</link>
         """;
 
+    private static ReactorPopup? _popup;
+
     public static void Show()
     {
-        DisconnectPopup.Instance.ShowCustom(Message);
+        if (_popup == null)
+        {
+            _popup = ReactorPopup.Create(nameof(HandshakePopup));
+            _popup.Background.transform.localPosition = new Vector3(0, 0.20f, 0);
+            _popup.Background.size = new Vector2(6.5f, 1.7f);
+            _popup.BackButton.transform.SetLocalY(-0.2f);
+        }
+
+        _popup.Show(Message);
     }
 }

--- a/Reactor/Networking/HandshakePopup.cs
+++ b/Reactor/Networking/HandshakePopup.cs
@@ -5,7 +5,7 @@ internal static class HandshakePopup
     public const string Message =
         """
         This server doesn't support Reactor's modded handshake.
-        The lobbies shown may be incompatible with your current mods.
+        The lobbies shown could be incompatible with your current mods.
         For more info see <link=https://reactor.gg/handshake>reactor.gg/handshake</link>
         """;
 

--- a/Reactor/Networking/HandshakePopup.cs
+++ b/Reactor/Networking/HandshakePopup.cs
@@ -1,0 +1,16 @@
+namespace Reactor.Networking;
+
+internal static class HandshakePopup
+{
+    public const string Message =
+        """
+        This server doesn't support modded handshake.
+        The lobbies shown may be incompatible with your current mods.
+        For more info see <link=https://reactor.gg/handshake>reactor.gg/handshake</link>
+        """;
+
+    public static void Show()
+    {
+        DisconnectPopup.Instance.ShowCustom(Message);
+    }
+}

--- a/Reactor/Networking/HandshakePopup.cs
+++ b/Reactor/Networking/HandshakePopup.cs
@@ -24,6 +24,12 @@ internal static class HandshakePopup
             _popup.BackButton.transform.SetLocalY(-0.2f);
         }
 
-        _popup.Show(Message);
+        var message = ReactorConfig.HandshakePopupMessage.Value;
+        if (string.IsNullOrEmpty(message))
+        {
+            message = Message;
+        }
+
+        _popup.Show(message);
     }
 }

--- a/Reactor/Networking/HandshakePopup.cs
+++ b/Reactor/Networking/HandshakePopup.cs
@@ -4,7 +4,7 @@ internal static class HandshakePopup
 {
     public const string Message =
         """
-        This server doesn't support modded handshake.
+        This server doesn't support Reactor's modded handshake.
         The lobbies shown may be incompatible with your current mods.
         For more info see <link=https://reactor.gg/handshake>reactor.gg/handshake</link>
         """;

--- a/Reactor/Networking/MakePublicDisallowedPopup.cs
+++ b/Reactor/Networking/MakePublicDisallowedPopup.cs
@@ -23,6 +23,12 @@ internal static class MakePublicDisallowedPopup
             _popup.BackButton.transform.SetLocalY(-0.1f);
         }
 
-        _popup.Show(Message);
+        var message = ReactorConfig.MakePublicDisallowedPopupMessage.Value;
+        if (string.IsNullOrEmpty(message))
+        {
+            message = Message;
+        }
+
+        _popup.Show(message);
     }
 }

--- a/Reactor/Networking/MakePublicDisallowedPopup.cs
+++ b/Reactor/Networking/MakePublicDisallowedPopup.cs
@@ -1,5 +1,5 @@
+using Reactor.Utilities.UI;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Reactor.Networking;
 
@@ -8,17 +8,21 @@ internal static class MakePublicDisallowedPopup
     public const string Message =
         """
         You can't make public lobbies on servers that don't support modded handshake.
-        For more info see https://reactor.gg/handshake
+        For more info see <link=https://reactor.gg/handshake>reactor.gg/handshake</link>
         """;
+
+    private static ReactorPopup? _popup;
 
     public static void Show()
     {
-        var popup = Object.Instantiate(DiscordManager.Instance.discordPopup, Camera.main!.transform);
-        var background = popup.transform.Find("Background").GetComponent<SpriteRenderer>();
-        var size = background.size;
-        size.x *= 2.5f;
-        background.size = size;
-        popup.TextAreaTMP.fontSizeMin = 2;
-        popup.Show(Message);
+        if (_popup == null)
+        {
+            _popup = ReactorPopup.Create(nameof(MakePublicDisallowedPopup));
+            _popup.Background.transform.localPosition = new Vector3(0, 0.25f, 0);
+            _popup.Background.size = new Vector2(7.5f, 1.5f);
+            _popup.BackButton.transform.SetLocalY(-0.1f);
+        }
+
+        _popup.Show(Message);
     }
 }

--- a/Reactor/Networking/MakePublicDisallowedPopup.cs
+++ b/Reactor/Networking/MakePublicDisallowedPopup.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Reactor.Networking;
+
+internal static class MakePublicDisallowedPopup
+{
+    public const string Message =
+        """
+        You can't make public lobbies on servers that don't support modded handshake.
+        For more info see https://reactor.gg/handshake
+        """;
+
+    public static void Show()
+    {
+        var popup = Object.Instantiate(DiscordManager.Instance.discordPopup, Camera.main!.transform);
+        var background = popup.transform.Find("Background").GetComponent<SpriteRenderer>();
+        var size = background.size;
+        size.x *= 2.5f;
+        background.size = size;
+        popup.TextAreaTMP.fontSizeMin = 2;
+        popup.Show(Message);
+    }
+}

--- a/Reactor/Networking/Patches/HttpPatches.cs
+++ b/Reactor/Networking/Patches/HttpPatches.cs
@@ -84,7 +84,7 @@ internal static class HttpPatches
 
                     if (__instance.GetMethod() == UnityWebRequest.UnityWebRequestMethod.Get)
                     {
-                        if (responseHeader == null && ModList.IsAnyModRequiredOnAllClients && !ReactorConfig.IgnoreHandshakePopup.Value)
+                        if (responseHeader == null && ModList.IsAnyModRequiredOnAllClients)
                         {
                             HandshakePopup.Show();
                         }

--- a/Reactor/Networking/Patches/HttpPatches.cs
+++ b/Reactor/Networking/Patches/HttpPatches.cs
@@ -5,7 +5,6 @@ using HarmonyLib;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.UI;
-using Object = UnityEngine.Object;
 
 namespace Reactor.Networking.Patches;
 
@@ -85,9 +84,9 @@ internal static class HttpPatches
 
                     if (__instance.GetMethod() == UnityWebRequest.UnityWebRequestMethod.Get)
                     {
-                        if (responseHeader == null)
+                        if (responseHeader == null && ModList.IsAnyModRequiredOnAllClients && !ReactorConfig.IgnoreHandshakePopup.Value)
                         {
-                            DisconnectPopup.Instance.ShowCustom("This region doesn't support modded handshake.\nThe lobbies shown may not be compatible with your current mods.\nFor more info see https://reactor.gg/handshake");
+                            HandshakePopup.Show();
                         }
                     }
 
@@ -118,16 +117,7 @@ internal static class HttpPatches
                 __instance.MakePublicButton.sprite = __instance.PrivateGameImage;
 
                 var onClick = __instance.MakePublicButton.GetComponent<PassiveButton>().OnClick = new Button.ButtonClickedEvent();
-                onClick.AddListener((Action) (() =>
-                {
-                    var popup = Object.Instantiate(DiscordManager.Instance.discordPopup, Camera.main!.transform);
-                    var background = popup.transform.Find("Background").GetComponent<SpriteRenderer>();
-                    var size = background.size;
-                    size.x *= 2.5f;
-                    background.size = size;
-                    popup.TextAreaTMP.fontSizeMin = 2;
-                    popup.Show("You can't make public lobbies on regions that don't support modded handshake.\nFor more info see https://reactor.gg/handshake");
-                }));
+                onClick.AddListener((Action) MakePublicDisallowedPopup.Show);
 
                 if (AmongUsClient.Instance.AmHost && AmongUsClient.Instance.IsGamePublic)
                 {

--- a/Reactor/ReactorConfig.cs
+++ b/Reactor/ReactorConfig.cs
@@ -7,11 +7,9 @@ internal static class ReactorConfig
     public const string FeaturesSection = "Features";
 
     public static ConfigEntry<bool> ForceDisableServerAuthority { get; private set; } = null!;
-    public static ConfigEntry<bool> IgnoreHandshakePopup { get; private set; } = null!;
 
     public static void Bind(ConfigFile config)
     {
         ForceDisableServerAuthority = config.Bind(FeaturesSection, nameof(ForceDisableServerAuthority), false, "Enables the DisableServerAuthority flag even when no mods declare it");
-        IgnoreHandshakePopup = config.Bind(FeaturesSection, nameof(IgnoreHandshakePopup), false, "Disables the \"This server doesn't support modded handshake\" popup");
     }
 }

--- a/Reactor/ReactorConfig.cs
+++ b/Reactor/ReactorConfig.cs
@@ -5,11 +5,18 @@ namespace Reactor;
 internal static class ReactorConfig
 {
     public const string FeaturesSection = "Features";
+    public const string MessagesSection = "Messages";
 
     public static ConfigEntry<bool> ForceDisableServerAuthority { get; private set; } = null!;
+
+    public static ConfigEntry<string> HandshakePopupMessage { get; private set; } = null!;
+    public static ConfigEntry<string> MakePublicDisallowedPopupMessage { get; private set; } = null!;
 
     public static void Bind(ConfigFile config)
     {
         ForceDisableServerAuthority = config.Bind(FeaturesSection, nameof(ForceDisableServerAuthority), false, "Enables the DisableServerAuthority flag even when no mods declare it");
+
+        HandshakePopupMessage = config.Bind(MessagesSection, nameof(HandshakePopupMessage), string.Empty);
+        MakePublicDisallowedPopupMessage = config.Bind(MessagesSection, nameof(MakePublicDisallowedPopupMessage), string.Empty);
     }
 }

--- a/Reactor/ReactorConfig.cs
+++ b/Reactor/ReactorConfig.cs
@@ -7,9 +7,11 @@ internal static class ReactorConfig
     public const string FeaturesSection = "Features";
 
     public static ConfigEntry<bool> ForceDisableServerAuthority { get; private set; } = null!;
+    public static ConfigEntry<bool> IgnoreHandshakePopup { get; private set; } = null!;
 
     public static void Bind(ConfigFile config)
     {
         ForceDisableServerAuthority = config.Bind(FeaturesSection, nameof(ForceDisableServerAuthority), false, "Enables the DisableServerAuthority flag even when no mods declare it");
+        IgnoreHandshakePopup = config.Bind(FeaturesSection, nameof(IgnoreHandshakePopup), false, "Disables the \"This server doesn't support modded handshake\" popup");
     }
 }

--- a/Reactor/Utilities/UI/ReactorPopup.cs
+++ b/Reactor/Utilities/UI/ReactorPopup.cs
@@ -1,0 +1,58 @@
+using Il2CppInterop.Runtime.Attributes;
+using Reactor.Utilities.Attributes;
+using TMPro;
+using UnityEngine;
+
+namespace Reactor.Utilities.UI;
+
+/// <summary>
+/// Wrapper over <see cref="GenericPopup"/> that adds hyperlink and controller support.
+/// </summary>
+[RegisterInIl2Cpp]
+internal sealed class ReactorPopup : MonoBehaviour
+{
+    private readonly Il2CppSystem.Collections.Generic.List<SelectableHyperLink> _selectableHyperLinks = new();
+
+    public GenericPopup Popup { get; private set; } = null!;
+    public TextMeshPro TextArea { get; private set; } = null!;
+    public PassiveButton BackButton { get; private set; } = null!;
+    public SpriteRenderer Background { get; private set; } = null!;
+
+    [HideFromIl2Cpp]
+    public void Show(string text)
+    {
+        Popup.Show(text);
+
+        ControllerManager.Instance.OpenOverlayMenu(name, BackButton);
+
+        SelectableHyperLinkHelper.AddSelectableUiForHyperlinks(_selectableHyperLinks, name);
+        TextArea.text = SelectableHyperLinkHelper.DecomposeAnnouncementText(TextArea, _selectableHyperLinks, name, TextArea.text);
+        SelectableHyperLinkHelper.UpdateHyperlinkPositions(TextArea, _selectableHyperLinks, name);
+
+        ControllerManager.Instance.AddSelectableUiElement(BackButton, true);
+    }
+
+    public void OnDisable()
+    {
+        ControllerManager.Instance.CloseOverlayMenu(name);
+    }
+
+    [HideFromIl2Cpp]
+    public static ReactorPopup Create(string name)
+    {
+        var genericPopup = Instantiate(DiscordManager.Instance.discordPopup, Camera.main!.transform);
+        var gameObject = genericPopup.gameObject;
+        var reactorPopup = gameObject.AddComponent<ReactorPopup>();
+
+        reactorPopup.Popup = genericPopup;
+        reactorPopup.TextArea = genericPopup.TextAreaTMP;
+        reactorPopup.BackButton = gameObject.transform.Find("ExitGame").GetComponent<PassiveButton>();
+        reactorPopup.Background = gameObject.transform.Find("Background").GetComponent<SpriteRenderer>();
+
+        gameObject.name = name;
+        genericPopup.destroyOnClose = true;
+        reactorPopup.TextArea.fontSizeMin = 2;
+
+        return reactorPopup;
+    }
+}


### PR DESCRIPTION
- Only show the popup when there is a mod with the `RequireOnAllClients` flag installed (not sure why this wasn't the case before)
- Change "region" to "server"
- Make the link clickable

![HandshakePopup](https://github.com/NuclearPowered/Reactor/assets/35262707/1de5b582-4dd3-48a2-97c8-d4abf5b394d6)
![MakePublicDisallowedPopup](https://github.com/NuclearPowered/Reactor/assets/35262707/537860a0-1044-4dec-86c8-3c04f2d871f1)

Closes #75 