### PR TITLE
Fix MainMenu scene load stuff because AU broke it somehow

### DIFF
--- a/Reactor/Patches/ReactorVersionShower.cs
+++ b/Reactor/Patches/ReactorVersionShower.cs
@@ -39,7 +39,7 @@ public static class ReactorVersionShower
 
     internal static void Initialize()
     {
-        SceneManager.add_sceneLoaded((Action<Scene, LoadSceneMode>) ((scene, _) =>
+        SceneManager.add_activeSceneChanged((Action<Scene, Scene>) ((_, scene) =>
         {
             var original = UnityEngine.Object.FindObjectOfType<VersionShower>();
             if (!original)

--- a/Reactor/ReactorPlugin.cs
+++ b/Reactor/ReactorPlugin.cs
@@ -70,7 +70,7 @@ public partial class ReactorPlugin : BasePlugin
         FreeNamePatch.Initialize();
         DefaultBundle.Load();
 
-        SceneManager.add_sceneLoaded((Action<Scene, LoadSceneMode>) ((scene, _) =>
+        SceneManager.add_activeSceneChanged((Action<Scene, Scene>) ((_, scene) =>
         {
             if (scene.name == "MainMenu")
             {


### PR DESCRIPTION
In recent versions (probably 2024.3.5), MainMenu scene doesn't trigger scene loaded, so use scene changed instead to fix it