### PR TITLE
Fix judge of custom server from findgamebycode

### DIFF
--- a/Reactor/Patches/Miscellaneous/CustomServersPatch.cs
+++ b/Reactor/Patches/Miscellaneous/CustomServersPatch.cs
@@ -7,6 +7,9 @@ namespace Reactor.Patches.Miscellaneous;
 [HarmonyPatch]
 internal static class CustomServersPatch
 {
+    private static StringNames? _lastFindGameRegion;
+    private static string? _lastFindGameIp;
+
     private static bool IsCurrentServerOfficial()
     {
         const string Domain = "among.us";
@@ -16,17 +19,45 @@ internal static class CustomServersPatch
                regionInfo.Servers.All(serverInfo => serverInfo.Ip.EndsWith(Domain, StringComparison.Ordinal));
     }
 
+    private static bool IsCurrentServerOfficialByStringNames(StringNames name)
+    {
+        return name is StringNames.ServerNA or StringNames.ServerEU or StringNames.ServerAS;
+    }
+
+    private static bool IsCurrentServerOfficialByFindGameInfo()
+    {
+        return _lastFindGameRegion is { } region && IsCurrentServerOfficialByStringNames(region)
+            && AmongUsClient.Instance.networkAddress == _lastFindGameIp;
+    }
+
+    [HarmonyPatch(typeof(EnterCodeManager), nameof(EnterCodeManager.FindGameResult))]
+    [HarmonyPostfix]
+    public static void CacheRegionAndIpOnFindGame(
+    EnterCodeManager __instance,
+    [HarmonyArgument(0)] HttpMatchmakerManager.FindGameByCodeResponse response)
+    {
+        if (response == null)
+        {
+            return;
+        }
+
+        _lastFindGameRegion = response.Region;
+        _lastFindGameIp = response.Game?.IPString;
+    }
+
     [HarmonyPatch(typeof(AuthManager._CoConnect_d__4), nameof(AuthManager._CoConnect_d__4.MoveNext))]
     [HarmonyPatch(typeof(AuthManager._CoWaitForNonce_d__6), nameof(AuthManager._CoWaitForNonce_d__6.MoveNext))]
     [HarmonyPrefix]
     public static bool DisableAuthServer(ref bool __result)
     {
-        if (IsCurrentServerOfficial())
+        if (IsCurrentServerOfficial() || IsCurrentServerOfficialByFindGameInfo())
         {
+            // Info("Exchanging nonce since target server is official.");
             return true;
         }
 
         __result = false;
+        // Info("Skipped nonce since target server is custom");
         return false;
     }
 


### PR DESCRIPTION
Server issued by the new FindGameByCode can be different from the one set in ServerManager.

This means that if we find a game on officials, but ServerManager's region is set to a modded server, dtls nonce will be skipped, thus resulting in auth failure.

This pr attempts to ease the issue by logging the FindGameByCode response, record the ip and the region name and compare it on actual joining the server.

The code does not seem to fit in the current codebase so changes are welcome.

<img width="812" height="302" alt="image" src="https://github.com/user-attachments/assets/3a57ea40-029f-43d1-b4d8-9f69165c5988" />
