### PR TITLE
Method rpc annotation can define a Target Client parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ riderModule.iml
 /_ReSharper.Caches/
 .idea
 /tools
-.vscode
+.vs*
 *.DotSettings.user

--- a/Reactor.Example/CustomRpcs.cs
+++ b/Reactor.Example/CustomRpcs.cs
@@ -4,4 +4,5 @@ public enum CustomRpcCalls : uint
 {
     Example,
     MethodRpcExample,
+    TargetRpcExample,
 }

--- a/Reactor.Example/ExamplePlugin.cs
+++ b/Reactor.Example/ExamplePlugin.cs
@@ -99,4 +99,10 @@ public partial class ExamplePlugin : BasePlugin
     {
         Logger<ExamplePlugin>.Info($"{player.Data.PlayerName} text: {text} number: {number} testPlayer: {testPlayer.NetId}");
     }
+
+    [MethodRpc((uint) CustomRpcCalls.TargetRpcExample, nameof(target))]
+    public static void RpcSayTo(PlayerControl player, PlayerControl target, string text)
+    {
+        Logger<ExamplePlugin>.Info($"{player.Data.PlayerName} text: {text} sentOnlyTo: {target.NetId}");
+    }
 }

--- a/Reactor/Networking/Attributes/MethodRpcAttribute.cs
+++ b/Reactor/Networking/Attributes/MethodRpcAttribute.cs
@@ -24,6 +24,11 @@ public sealed class MethodRpcAttribute : Attribute
     public uint Id { get; }
 
     /// <summary>
+    /// Gets the method's parameter to get the target client, if any.
+    /// </summary>
+    public string? TargetParameter { get; }
+
+    /// <summary>
     /// Gets or sets the send option of the rpc.
     /// </summary>
     public SendOption SendOption { get; set; } = SendOption.Reliable;
@@ -43,9 +48,11 @@ public sealed class MethodRpcAttribute : Attribute
     /// Initializes a new instance of the <see cref="MethodRpcAttribute"/> class.
     /// </summary>
     /// <param name="id">The id of the rpc.</param>
-    public MethodRpcAttribute(uint id)
+    /// <param name="targetParam">The parameter to get the target client from, if any.</param>
+    public MethodRpcAttribute(uint id, string? targetParam = null)
     {
         Id = id;
+        TargetParameter = targetParam;
     }
 
     /// <summary>
@@ -72,7 +79,7 @@ public sealed class MethodRpcAttribute : Attribute
 
             try
             {
-                var customRpc = new MethodRpc(plugin, method, attribute.Id, attribute.SendOption, attribute.LocalHandling);
+                var customRpc = new MethodRpc(plugin, method, attribute.Id, attribute.SendOption, attribute.LocalHandling, attribute.TargetParameter);
                 PluginSingleton<ReactorPlugin>.Instance.CustomRpcManager.Register(customRpc);
             }
             catch (Exception e)

--- a/Reactor/Networking/Attributes/MethodRpcAttribute.cs
+++ b/Reactor/Networking/Attributes/MethodRpcAttribute.cs
@@ -49,10 +49,19 @@ public sealed class MethodRpcAttribute : Attribute
     /// </summary>
     /// <param name="id">The id of the rpc.</param>
     /// <param name="targetParam">The parameter to get the target client from, if any.</param>
-    public MethodRpcAttribute(uint id, string? targetParam = null)
+    public MethodRpcAttribute(uint id, string? targetParam)
     {
         Id = id;
         TargetParameter = targetParam;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MethodRpcAttribute"/> class.
+    /// </summary>
+    /// <param name="id">The id of the rpc.</param>
+    public MethodRpcAttribute(uint id)
+        : this(id, null)
+    {
     }
 
     /// <summary>

--- a/Reactor/Networking/Rpc/MethodRpc.cs
+++ b/Reactor/Networking/Rpc/MethodRpc.cs
@@ -32,11 +32,13 @@ public class MethodRpc : UnsafeCustomRpc
     /// <param name="id">The id of the rpc.</param>
     /// <param name="option">The send option of the rpc.</param>
     /// <param name="localHandling">The local handling method of the rpc.</param>
-    public MethodRpc(BasePlugin plugin, MethodInfo method, uint id, SendOption option, RpcLocalHandling localHandling) : base(plugin, id)
+    /// <param name="targetParam">The parameter to get the target client from, if any.</param>
+    public MethodRpc(BasePlugin plugin, MethodInfo method, uint id, SendOption option, RpcLocalHandling localHandling, string? targetParam) : base(plugin, id)
     {
         Method = method;
         LocalHandling = localHandling;
         SendOption = option;
+        TargetParameter = targetParam;
 
         var parameters = method.GetParameters();
 
@@ -78,9 +80,10 @@ public class MethodRpc : UnsafeCustomRpc
     /// <param name="option">The send option of the rpc.</param>
     /// <param name="localHandling">The local handling method of the rpc.</param>
     /// <param name="sendImmediately">The value indicating whether the rpc should be sent immediately.</param>
+    /// <param name="targetParam">The parameter to get the target client from, if any.</param>
     [Obsolete("Non-immediate RPCs were removed in 2025.5.20. All RPCs are immediate. Remove sendImmediately from the parameter list.")]
-    public MethodRpc(BasePlugin plugin, MethodInfo method, uint id, SendOption option, RpcLocalHandling localHandling, bool sendImmediately)
-        : this(plugin, method, id, option, localHandling)
+    public MethodRpc(BasePlugin plugin, MethodInfo method, uint id, SendOption option, RpcLocalHandling localHandling, bool sendImmediately, string? targetParam)
+        : this(plugin, method, id, option, localHandling, targetParam)
     {
         SendImmediately = sendImmediately;
     }
@@ -89,6 +92,11 @@ public class MethodRpc : UnsafeCustomRpc
     /// Gets the method of the method rpc.
     /// </summary>
     public MethodInfo Method { get; }
+
+    /// <summary>
+    /// Gets the method's parameter to get the target client, if any.
+    /// </summary>
+    public string? TargetParameter { get; }
 
     /// <inheritdoc />
     protected internal override bool IsSingleton => false;

--- a/Reactor/Networking/Rpc/MethodRpc.cs
+++ b/Reactor/Networking/Rpc/MethodRpc.cs
@@ -68,6 +68,20 @@ public class MethodRpc : UnsafeCustomRpc
             InnerNetObjectType = method.DeclaringType;
         }
 
+        if (TargetParameter != null)
+        {
+            var param = Array.Find(parameters, p => p.Name == TargetParameter);
+            if (param == null)
+            {
+                throw new ArgumentException("Target Client parameter isn't part of method rpc signature.", nameof(method));
+            }
+            if (!typeof(PlayerControl).IsAssignableFrom(param.ParameterType) ||
+                !typeof(int).IsAssignableFrom(param.ParameterType))
+            {
+                throw new ArgumentException("Target Client parameter has to be a PlayerControl or int", nameof(method));
+            }
+        }
+
         _handle = Hook(method, parameters, method.IsStatic);
     }
 
@@ -155,9 +169,10 @@ public class MethodRpc : UnsafeCustomRpc
     /// </summary>
     /// <param name="innerNetObject">The <see cref="InnerNetObject"/> to send the rpc on.</param>
     /// <param name="args">The arguments to serialize and send.</param>
-    public void Send(InnerNetObject innerNetObject, object[] args)
+    /// <param name="targetClientId">The id of the target client. -1 broadcasts without specific target.</param>
+    public void Send(InnerNetObject innerNetObject, object[] args, int targetClientId = -1)
     {
-        UnsafeSend(innerNetObject, args);
+        UnsafeSend(innerNetObject, args, targetClientId: targetClientId);
     }
 
     private static readonly MethodInfo _sendMethod = AccessTools.Method(typeof(MethodRpc), nameof(Send));
@@ -182,6 +197,12 @@ public class MethodRpc : UnsafeCustomRpc
             foreach (var parameter in parameters)
             {
                 dynamicMethod.DefineParameter(parameter.Position + (isStatic ? 0 : 1), ParameterAttributes.None, parameter.Name);
+            }
+
+            var targetClientIndex = -1;
+            if (TargetParameter != null)
+            {
+                targetClientIndex = Array.FindIndex(parameters, p => p.Name == TargetParameter);
             }
 
             var il = dynamicMethod.GetILGenerator();
@@ -237,6 +258,21 @@ public class MethodRpc : UnsafeCustomRpc
                 }
 
                 il.Emit(OpCodes.Stelem_Ref);
+            }
+
+            if (targetClientIndex >= 0)
+            {
+                il.Emit(OpCodes.Ldarg, targetClientIndex);
+
+                var parameter = parameters[targetClientIndex];
+                if (typeof(PlayerControl).IsAssignableFrom(parameter.ParameterType))
+                {
+                    il.Emit(OpCodes.Ldfld, typeof(PlayerControl).GetField(nameof(PlayerControl.PlayerId), BindingFlags.Instance | BindingFlags.Public)!);
+                }
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I4_M1);
             }
 
             il.Emit(OpCodes.Call, _sendMethod);


### PR DESCRIPTION
Expands the existing MethodRpc annotation so a parameter of the method it is annotating can be assigned to mark the "TargetClientId" that SendRpcImmediately uses to not broadcast rpc to all.